### PR TITLE
WTI crude oil 5-day return prediction: walk-forward ML pipeline

### DIFF
--- a/crude-ml-prediction/.gitignore
+++ b/crude-ml-prediction/.gitignore
@@ -1,0 +1,7 @@
+data/
+results/*.csv
+__pycache__/
+*.pyc
+*.pyo
+.ipynb_checkpoints/
+.venv/

--- a/crude-ml-prediction/README.md
+++ b/crude-ml-prediction/README.md
@@ -1,0 +1,124 @@
+# WTI Crude Oil 5-Day Return Prediction
+
+Walk-forward validated machine learning pipeline that predicts 5-day-forward WTI crude oil returns from macro and cross-asset features, and backtests a simple long/short/flat trading strategy net of transaction costs.
+
+Built as a portfolio project for quantitative finance internship applications — the emphasis is on methodological rigor (no lookahead bias, expanding-window out-of-sample validation, honest cost accounting) over chasing an impressive backtest number.
+
+## Key Results
+
+*Fill in after running `python main.py` — see [How to Run](#how-to-run). Do not trust these numbers until they come from an actual run; they are not invented.*
+
+Out-of-sample period: 2019 – most recent complete year, walk-forward (expanding window, retrained annually).
+
+| Model    | Sharpe (net) | Sharpe (gross) | Ann. Return (net) | Max Drawdown (net) | Hit Rate | IC (Spearman) |
+|----------|:---:|:---:|:---:|:---:|:---:|:---:|
+| Baseline (always 0) | X.XX | X.XX | X.XX% | X.XX% | X.XX% | X.XX |
+| Ridge    | X.XX | X.XX | X.XX% | X.XX% | X.XX% | X.XX |
+| Lasso    | X.XX | X.XX | X.XX% | X.XX% | X.XX% | X.XX |
+| XGBoost  | X.XX | X.XX | X.XX% | X.XX% | X.XX% | X.XX |
+| Buy & Hold WTI (benchmark) | X.XX | — | X.XX% | X.XX% | — | — |
+
+Full numbers (per-year breakdown included) are written to `results/metrics.json` on every run. Charts: `results/equity_curve.png`, `results/feature_importance.png`, `results/pred_scatter.png`.
+
+> **If a strategy Sharpe comes out above ~2.5**, treat that as a red flag, not a win — daily/weekly macro-feature strategies essentially never sustain a Sharpe that high out-of-sample. Re-run `verify_no_lookahead()` and audit the fold boundaries and scaler-fitting logic before trusting it. A modest or even negative net Sharpe with clean methodology is a legitimate result for this kind of project.
+
+## Methodology
+
+### Data
+
+Daily Close prices, 2010-01-01 to present, from `yfinance` (no API key required):
+
+| Ticker | Series |
+|---|---|
+| `CL=F` | WTI crude (prediction target) |
+| `BZ=F` | Brent crude |
+| `RB=F` | RBOB gasoline |
+| `DX-Y.NYB` | US Dollar Index |
+| `^TNX` | US 10-Year Treasury yield |
+| `XLE` | Energy sector ETF |
+| `^VIX` | CBOE Volatility Index |
+
+Series are aligned to a common trading calendar; gaps up to 3 consecutive days are forward-filled (minor exchange-calendar mismatches), longer gaps are dropped rather than papered over. Prices are cached to `data/prices.parquet` so repeat runs don't re-hit yfinance.
+
+An **optional** EIA weekly crude inventory module (`fetch_eia_inventories`) activates only if an `EIA_API_KEY` environment variable is set, and is skipped silently otherwise — the base pipeline requires zero API keys.
+
+### Features
+
+| Feature | Rationale |
+|---|---|
+| `mom_5d` / `mom_21d` / `mom_63d` | Short-run trend persistence — crude exhibits CTA/systematic-flow-driven momentum at multiple horizons |
+| `realized_vol_21d` | Volatility clustering (GARCH effect); regime context for return magnitude |
+| `brent_wti_spread` (level, 5d Δ) | Regional supply/demand tightness proxy (Cushing storage, export/transport bottlenecks) |
+| `crack_spread_proxy_5d` | RBOB − WTI return, rolling sum; refining-margin momentum leads crude via downstream demand |
+| `dxy_chg_5d` / `dxy_chg_21d` | Dollar strength is a mechanical headwind for a dollar-denominated global commodity |
+| `ust10y_chg_5d` | Growth/inflation expectations, discount rate on future energy demand |
+| `vix_level`, `vix_chg_5d` | Broad risk-appetite regime; commodity de-risking often follows equity vol spikes |
+| `xle_relative_strength_21d` | Energy-equity investors often re-price forward earnings ahead of spot crude |
+| `inventory_surprise` *(optional, EIA key only)* | Weekly stock change vs. trailing 4-week average change — how unusual the latest EIA print was |
+
+Target: forward 5-day WTI log return, `log(P[t+5]) − log(P[t])`.
+
+### Walk-forward validation
+
+Expanding window, retrained once per calendar year — never a random train/test split, which would let the model train on data from *after* the period it's scored on:
+
+```
+Fold 1: train [2010 .. 2018] -> predict 2019
+Fold 2: train [2010 .. 2019] -> predict 2020
+Fold 3: train [2010 .. 2020] -> predict 2021
+   ...
+Fold N: train [2010 .. Y-1]  -> predict Y   (Y = most recent complete calendar year)
+```
+
+Inside each fold, `StandardScaler` is fit on the training rows only and applied to the test rows — fitting it on the full dataset before splitting would leak the test period's mean/variance backward into training.
+
+### Strategy construction
+
+- Predictions are made **every 5 trading days** within each fold (non-overlapping), so each position is held for exactly the horizon it was sized for — no overlapping-holding-period bookkeeping to get wrong.
+- Position: **long** if predicted return > threshold, **short** if < −threshold, **flat** otherwise.
+- Adaptive threshold = `0.25 × rolling_std(recent predictions)` — scales the conviction bar to each model's own signal dispersion instead of a hand-picked fixed cutoff that would suit some models and not others.
+- Transaction costs: **3 bps per unit of position change** (e.g. flat→long costs 1 unit, long→short costs 2 units, reflecting two legs). Results are reported both gross and net of costs.
+
+### Models
+
+| Model | Notes |
+|---|---|
+| `baseline` | Always predicts 0 — the "no edge" null hypothesis every other model must beat |
+| `ridge` | `Ridge(alpha=1.0)` |
+| `lasso` | `Lasso(alpha=0.001)` — sparse, doubles as feature selection |
+| `xgboost` | `max_depth=3`, `n_estimators=100`, `learning_rate=0.05`, row/column subsampling at 0.8 — deliberately shallow, since daily financial data has a low signal-to-noise ratio and a high-capacity tree ensemble will happily memorize training-window noise |
+
+## Why No Lookahead Bias
+
+This is the part of the project meant to differentiate it from a typical Kaggle-style backtest:
+
+1. **Every feature is provably causal.** `verify_no_lookahead()` recomputes the entire feature set on a *truncated* price history for a random sample of dates and asserts the result is identical to the value stored in the full feature matrix — if any feature secretly depended on future rows (a centered window, an off-by-one shift), truncating the input would change its value and the check would fail loudly.
+2. **Target alignment is checked independently** — for the same sample of dates, the forward 5-day return is recomputed by hand from raw prices and compared against the stored target column, catching horizon/shift bugs.
+3. **Scaling never sees the future.** `StandardScaler` is refit inside every walk-forward fold on that fold's training rows only, never on the full dataset.
+4. **Trading only acts on already-known predictions.** The adaptive position threshold is a trailing (non-centered) rolling statistic of past predictions, so a trade decision at time *t* never depends on a prediction made after *t*.
+
+`main.py` runs `verify_no_lookahead()` before any backtesting starts, and the pipeline aborts if it fails.
+
+## How to Run
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+No API keys required. Total runtime is a few minutes (dominated by the initial yfinance download; subsequent runs use the `data/prices.parquet` cache). To enable the optional EIA inventory feature:
+
+```bash
+export EIA_API_KEY=your_key_here   # free at https://www.eia.gov/opendata/register.php
+python main.py
+```
+
+Outputs land in `results/`: `equity_curve.png`, `feature_importance.png`, `pred_scatter.png`, `metrics.json`, plus a console summary table.
+
+## Limitations & Next Steps
+
+- **No regime conditioning.** The model is trained identically across the 2020 demand-shock, the 2022 supply-shock inflation regime, and calmer periods. A regime-switching model (or regime as an explicit feature) would likely help.
+- **No confidence-weighted position sizing.** Positions are a flat ±1 unit; sizing proportional to prediction magnitude or an estimated confidence interval is a natural extension.
+- **Inventory data is weekly and coarse.** The optional EIA feature only uses the headline national number; PADD-level regional inventories, Cushing-specific stocks, and refinery utilization rates are all richer signals available from the same API.
+- **Retrain cadence is annual.** A shorter retrain cycle (quarterly/monthly) would react faster to regime shifts, at the cost of more frequent parameter instability — worth testing as a sensitivity check.
+- **No ensembling across models.** Averaging or stacking Ridge/Lasso/XGBoost predictions was deliberately left out to keep each model's standalone performance legible; combining them is a reasonable next step once each is well understood individually.

--- a/crude-ml-prediction/main.py
+++ b/crude-ml-prediction/main.py
@@ -1,0 +1,48 @@
+"""End-to-end pipeline: download data -> build features -> verify no lookahead
+bias -> walk-forward backtest four models -> evaluate and save results.
+
+Run with: python main.py
+"""
+
+from __future__ import annotations
+
+import time
+
+from src.backtest import run_backtest_all_models
+from src.data_loader import build_inventory_surprise_daily, download_prices, fetch_eia_inventories
+from src.evaluate import evaluate
+from src.features import build_feature_matrix, get_feature_columns, verify_no_lookahead
+from src.models import MODEL_NAMES
+
+
+def main() -> None:
+    start_time = time.time()
+
+    print("\n[1/5] Loading price data...")
+    prices = download_prices()
+
+    eia_weekly = fetch_eia_inventories()
+    eia_daily = (
+        build_inventory_surprise_daily(eia_weekly, prices.index) if eia_weekly is not None else None
+    )
+
+    print("\n[2/5] Building features...")
+    feature_matrix = build_feature_matrix(prices, eia_daily)
+    feature_cols = get_feature_columns(feature_matrix)
+    print(f"[main] Feature columns ({len(feature_cols)}): {feature_cols}")
+
+    print("\n[3/5] Verifying no lookahead bias...")
+    verify_no_lookahead(prices, feature_matrix, eia_daily)
+
+    print("\n[4/5] Running walk-forward backtest for all models...")
+    backtest_results = run_backtest_all_models(feature_matrix, feature_cols, MODEL_NAMES)
+
+    print("\n[5/5] Evaluating results...")
+    evaluate(backtest_results, feature_matrix, feature_cols, prices)
+
+    elapsed = time.time() - start_time
+    print(f"[main] Pipeline complete in {elapsed:.1f}s.")
+
+
+if __name__ == "__main__":
+    main()

--- a/crude-ml-prediction/notebooks/exploration.ipynb
+++ b/crude-ml-prediction/notebooks/exploration.ipynb
@@ -1,0 +1,241 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WTI Crude Oil — Exploratory Data Analysis\n",
+    "\n",
+    "This notebook is a first look at the raw data behind the 5-day WTI return prediction pipeline in `../src/`. It answers three questions before any modeling happens:\n",
+    "\n",
+    "1. What do the raw price series actually look like, and are there any obvious data quality issues (gaps, regime breaks, the 2020 negative-price event)?\n",
+    "2. What is the shape of the WTI daily return distribution — is it close to normal, or fat-tailed and skewed (as commodity returns typically are)?\n",
+    "3. How correlated are the candidate features with each other, and with the dollar index specifically, and does that correlation drift over time?\n",
+    "\n",
+    "It reuses `src/data_loader.py` and `src/features.py` directly so the EDA is guaranteed to be looking at exactly the same data the model pipeline sees."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# make `src` importable when running from notebooks/\n",
+    "sys.path.append(str(Path.cwd().parent))\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from src.data_loader import download_prices\n",
+    "from src.features import compute_price_features\n",
+    "\n",
+    "# Reuse the same light chart surface / ink palette as results/*.png for visual consistency.\n",
+    "COLOR_SURFACE = \"#fcfcfb\"\n",
+    "COLOR_GRID = \"#e1e0d9\"\n",
+    "COLOR_TEXT_PRIMARY = \"#0b0b0b\"\n",
+    "COLOR_TEXT_MUTED = \"#898781\"\n",
+    "SERIES_COLORS = [\"#2a78d6\", \"#1baf7a\", \"#eda100\", \"#008300\", \"#4a3aa7\", \"#e34948\", \"#e87ba4\"]\n",
+    "\n",
+    "plt.rcParams[\"figure.facecolor\"] = COLOR_SURFACE\n",
+    "plt.rcParams[\"axes.facecolor\"] = COLOR_SURFACE\n",
+    "plt.rcParams[\"axes.edgecolor\"] = COLOR_TEXT_MUTED\n",
+    "plt.rcParams[\"grid.color\"] = COLOR_GRID\n",
+    "plt.rcParams[\"text.color\"] = COLOR_TEXT_PRIMARY\n",
+    "plt.rcParams[\"axes.labelcolor\"] = COLOR_TEXT_PRIMARY\n",
+    "plt.rcParams[\"xtick.color\"] = COLOR_TEXT_MUTED\n",
+    "plt.rcParams[\"ytick.color\"] = COLOR_TEXT_MUTED"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uses the cached data/prices.parquet if main.py has already been run;\n",
+    "# otherwise this triggers a fresh yfinance download.\n",
+    "prices = download_prices()\n",
+    "prices.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Price levels\n",
+    "\n",
+    "Small multiples rather than one overlaid chart, since the series live on very different scales (WTI in $/bbl vs. VIX as an index level vs. the 10Y yield in percentage points) — overlaying them on a shared or dual axis would be misleading."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(4, 2, figsize=(13, 14))\n",
+    "axes = axes.flatten()\n",
+    "\n",
+    "for ax, (col, color) in zip(axes, zip(prices.columns, SERIES_COLORS)):\n",
+    "    ax.plot(prices.index, prices[col], color=color, linewidth=1.1)\n",
+    "    ax.set_title(col, loc=\"left\", fontweight=\"bold\", fontsize=11)\n",
+    "    ax.grid(True, linewidth=0.6)\n",
+    "    ax.set_axisbelow(True)\n",
+    "\n",
+    "axes[-1].axis(\"off\")\n",
+    "fig.suptitle(\"Raw price/level series, 2010–present\", fontsize=14, fontweight=\"bold\", x=0.02, ha=\"left\")\n",
+    "fig.tight_layout(rect=(0, 0, 1, 0.97))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the April 2020 WTI collapse (COVID demand shock plus the front-month futures contract briefly trading negative) — the single largest regime break in the sample. It's a real, tradeable event rather than a data error, so it is intentionally NOT removed or winsorized anywhere in the pipeline; the walk-forward validation just has to live with it in whichever training window it falls into, exactly as a live trading system would have."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. WTI daily return distribution\n",
+    "\n",
+    "Financial returns are famously not normally distributed — fatter tails (more extreme moves than a Gaussian predicts) and often mild skew. This matters for modeling choice: it's part of why we favor simple, regularized models and a coarse long/short/flat strategy over anything that implicitly assumes Gaussian errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wti_daily_logret = np.log(prices[\"WTI\"]).diff().dropna()\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(13, 5))\n",
+    "\n",
+    "ax1.hist(wti_daily_logret, bins=120, color=SERIES_COLORS[0], alpha=0.85)\n",
+    "ax1.axvline(0, color=COLOR_TEXT_MUTED, linewidth=1)\n",
+    "ax1.set_title(\"WTI daily log return distribution\", loc=\"left\", fontweight=\"bold\")\n",
+    "ax1.set_xlabel(\"Daily log return\")\n",
+    "ax1.grid(True, linewidth=0.6)\n",
+    "ax1.set_axisbelow(True)\n",
+    "\n",
+    "from scipy import stats  # noqa: E402  (local import to keep the top-level dependency list minimal)\n",
+    "stats.probplot(wti_daily_logret, dist=\"norm\", plot=ax2)\n",
+    "ax2.get_lines()[0].set_color(SERIES_COLORS[0])\n",
+    "ax2.get_lines()[0].set_markersize(3)\n",
+    "ax2.get_lines()[1].set_color(COLOR_TEXT_MUTED)\n",
+    "ax2.set_title(\"Q-Q plot vs. normal\", loc=\"left\", fontweight=\"bold\")\n",
+    "ax2.grid(True, linewidth=0.6)\n",
+    "ax2.set_axisbelow(True)\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"mean:     {wti_daily_logret.mean():.5f}\")\n",
+    "print(f\"std:      {wti_daily_logret.std():.5f}\")\n",
+    "print(f\"skew:     {wti_daily_logret.skew():.3f}\")\n",
+    "print(f\"kurtosis: {wti_daily_logret.kurtosis():.3f}  (0 = normal; WTI is typically fat-tailed/leptokurtic)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Feature correlation heatmap\n",
+    "\n",
+    "Built from `compute_price_features`, i.e. the exact feature set the models train on (minus the target). High pairwise correlation between two features is a flag for redundancy — useful context when reading the Lasso/XGBoost feature importance charts in `results/`, since a model may lean on one of two correlated features somewhat arbitrarily."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "feats = compute_price_features(prices).dropna()\n",
+    "corr = feats.corr()\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(9, 8))\n",
+    "im = ax.imshow(corr, cmap=\"RdBu_r\", vmin=-1, vmax=1)\n",
+    "ax.set_xticks(range(len(corr.columns)))\n",
+    "ax.set_xticklabels(corr.columns, rotation=90, fontsize=8)\n",
+    "ax.set_yticks(range(len(corr.columns)))\n",
+    "ax.set_yticklabels(corr.columns, fontsize=8)\n",
+    "for i in range(len(corr.columns)):\n",
+    "    for j in range(len(corr.columns)):\n",
+    "        ax.text(j, i, f\"{corr.iloc[i, j]:.2f}\", ha=\"center\", va=\"center\",\n",
+    "                fontsize=6, color=\"white\" if abs(corr.iloc[i, j]) > 0.6 else COLOR_TEXT_PRIMARY)\n",
+    "fig.colorbar(im, ax=ax, shrink=0.8, label=\"Pearson correlation\")\n",
+    "ax.set_title(\"Feature correlation matrix\", loc=\"left\", fontweight=\"bold\", pad=12)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Rolling correlation: WTI vs. the dollar index\n",
+    "\n",
+    "The \"stronger dollar = weaker commodities\" relationship is a textbook macro link, but it isn't stable — it strengthens and weakens with the macro regime (e.g. it tends to tighten during broad risk-off/dollar-funding-stress episodes). A single full-sample correlation number would hide that, so this plots a rolling window instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ROLLING_WINDOW = 126  # ~6 months of trading days\n",
+    "\n",
+    "wti_ret = np.log(prices[\"WTI\"]).diff()\n",
+    "dxy_ret = np.log(prices[\"DXY\"]).diff()\n",
+    "rolling_corr = wti_ret.rolling(ROLLING_WINDOW).corr(dxy_ret)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(11, 5))\n",
+    "ax.plot(rolling_corr.index, rolling_corr.values, color=SERIES_COLORS[0], linewidth=1.2)\n",
+    "ax.axhline(0, color=COLOR_TEXT_MUTED, linewidth=1)\n",
+    "ax.set_title(f\"Rolling {ROLLING_WINDOW}d correlation: WTI vs. DXY daily returns\", loc=\"left\", fontweight=\"bold\")\n",
+    "ax.set_ylabel(\"Correlation\")\n",
+    "ax.grid(True, linewidth=0.6)\n",
+    "ax.set_axisbelow(True)\n",
+    "fig.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Full-sample correlation: {wti_ret.corr(dxy_ret):.3f}\")\n",
+    "print(f\"Rolling correlation range: [{rolling_corr.min():.3f}, {rolling_corr.max():.3f}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Takeaways for modeling\n",
+    "\n",
+    "- WTI daily returns are fat-tailed relative to a normal distribution — regularized linear models and a shallow, subsampled XGBoost (see `src/models.py`) are a deliberate response to that low signal-to-noise environment, not an oversight.\n",
+    "- The dollar/crude relationship is regime-dependent, which is exactly why `dxy_chg_5d` / `dxy_chg_21d` are included as *changes* rather than relying on a single static correlation assumption baked into the feature.\n",
+    "- Several features are correlated (e.g. the momentum windows with each other, and the Brent-WTI spread level with its own 5-day change) — worth keeping in mind when interpreting `results/feature_importance.png`, since correlated features can split credit in ways that understate any one feature's true importance."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crude-ml-prediction/requirements.txt
+++ b/crude-ml-prediction/requirements.txt
@@ -1,0 +1,9 @@
+pandas==3.0.3
+numpy==2.4.6
+yfinance==1.5.1
+scikit-learn==1.9.0
+xgboost==3.2.0
+matplotlib==3.11.0
+statsmodels==0.14.6
+requests==2.34.2
+pyarrow==24.0.0

--- a/crude-ml-prediction/src/__init__.py
+++ b/crude-ml-prediction/src/__init__.py
@@ -1,0 +1,1 @@
+"""crude-ml-prediction: walk-forward validated WTI crude oil return prediction pipeline."""

--- a/crude-ml-prediction/src/backtest.py
+++ b/crude-ml-prediction/src/backtest.py
@@ -1,0 +1,242 @@
+"""Walk-forward validation and trading strategy backtest.
+
+Two things happen here, deliberately kept separate:
+
+1. **Walk-forward validation** (:func:`run_walk_forward`): an expanding
+   training window, retrained once per calendar year, used to generate
+   genuinely out-of-sample predictions for every model. This is what makes
+   the whole project honest -- a model never sees any data from the year
+   it is being scored on, and the ``StandardScaler`` is fit on the training
+   fold only (see the module docstring in ``features.py`` for why fitting
+   it on the full dataset would leak information).
+
+2. **Strategy construction** (:func:`build_positions`,
+   :func:`compute_strategy_returns`): turns those predictions into trading
+   positions and a P&L series, net of transaction costs.
+
+Two out-of-sample prediction sets come out of the walk-forward loop:
+
+* ``oos_daily`` -- a prediction for every trading day in the test years.
+  Because the label is a forward 5-day return, these overlap (today's
+  target and tomorrow's target share 4 days of price history), which makes
+  them unsuitable for compounding into a P&L series, but they give the
+  fullest, least noisy read on raw forecast skill (IC, scatter plot).
+* ``oos_trade`` -- one prediction every ``FORWARD_HORIZON`` trading days
+  (non-overlapping), used to build an actual position that is held for
+  exactly the horizon it was sized for. This is what the backtest P&L is
+  computed from.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+from src.features import FORWARD_HORIZON, TARGET_COL
+from src.models import get_model
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FIRST_TEST_YEAR = 2019  # first fold trains on 2010-2018, predicts 2019
+MIN_TRAIN_OBS = 500  # ~2 trading years; sanity floor before trusting a fold
+
+REBALANCE_STEP = FORWARD_HORIZON  # trade every 5 trading days -> non-overlapping holds
+
+TRANSACTION_COST_BPS = 3.0  # cost per unit of position change, in basis points
+TRANSACTION_COST = TRANSACTION_COST_BPS / 10_000.0
+
+# Adaptive entry/exit threshold: a position is only taken when the model's
+# predicted return exceeds a fraction of the recent dispersion of its own
+# predictions. This scales the "conviction bar" to each model's own signal
+# strength (a model with tiny, tightly-clustered predictions would almost
+# never trade under a fixed absolute threshold) rather than requiring us to
+# hand-pick a different fixed cutoff per model.
+THRESHOLD_VOL_MULTIPLIER = 0.25
+THRESHOLD_ROLLING_WINDOW = 10  # in units of trade periods (i.e. ~10 * 5 = 50 trading days)
+THRESHOLD_MIN_PERIODS = 4
+
+
+@dataclass
+class FoldResult:
+    test_year: int
+    n_train: int
+    n_test: int
+
+
+def _last_complete_year(index: pd.DatetimeIndex) -> int:
+    """Infer the most recent calendar year with a (near-)complete trading history.
+
+    A year is only treated as "complete" once data runs through at least
+    Dec 20 of that year; otherwise the prior year is used, so the final
+    walk-forward fold isn't scored on a handful of partial-year trading days.
+    """
+    last_date = index[-1]
+    if last_date.month == 12 and last_date.day >= 20:
+        return last_date.year
+    return last_date.year - 1
+
+
+def get_fold_boundaries(index: pd.DatetimeIndex) -> List[Tuple[pd.Timestamp, pd.Timestamp, pd.Timestamp, int]]:
+    """Build (train_end, test_start, test_end, test_year) tuples for each annual fold.
+
+    Expanding window: every fold's training set starts at the very first
+    available date and grows by one year each time, per the project spec
+    (train 2010-2018 -> predict 2019, train 2010-2019 -> predict 2020, ...).
+    """
+    last_complete_year = _last_complete_year(index)
+    folds = []
+    for test_year in range(FIRST_TEST_YEAR, last_complete_year + 1):
+        train_end = pd.Timestamp(year=test_year - 1, month=12, day=31)
+        test_start = pd.Timestamp(year=test_year, month=1, day=1)
+        test_end = pd.Timestamp(year=test_year, month=12, day=31)
+        folds.append((train_end, test_start, test_end, test_year))
+    return folds
+
+
+def run_walk_forward(
+    feature_matrix: pd.DataFrame,
+    feature_cols: List[str],
+    model_name: str,
+    target_col: str = TARGET_COL,
+) -> Tuple[pd.DataFrame, pd.DataFrame, List[FoldResult]]:
+    """Run expanding-window walk-forward validation for one model.
+
+    Returns ``(oos_daily, oos_trade, fold_results)``:
+
+    * ``oos_daily``: DataFrame[pred, actual] for every out-of-sample trading day.
+    * ``oos_trade``: DataFrame[pred, actual] sampled every ``REBALANCE_STEP``
+      trading days within each fold (non-overlapping trade dates).
+    * ``fold_results``: per-fold bookkeeping (train/test sizes) for logging.
+    """
+    folds = get_fold_boundaries(feature_matrix.index)
+    daily_frames = []
+    trade_frames = []
+    fold_results = []
+
+    for train_end, test_start, test_end, test_year in folds:
+        train_mask = feature_matrix.index <= train_end
+        test_mask = (feature_matrix.index >= test_start) & (feature_matrix.index <= test_end)
+
+        train_df = feature_matrix.loc[train_mask]
+        test_df = feature_matrix.loc[test_mask]
+
+        if len(train_df) < MIN_TRAIN_OBS or test_df.empty:
+            continue
+
+        X_train, y_train = train_df[feature_cols].values, train_df[target_col].values
+        X_test, y_test = test_df[feature_cols].values, test_df[target_col].values
+
+        # Scaler fit on TRAIN ONLY, then applied to test -- this is the crux
+        # of avoiding lookahead bias in preprocessing: the test fold's mean
+        # and variance never influence the transform.
+        scaler = StandardScaler()
+        X_train_scaled = scaler.fit_transform(X_train)
+        X_test_scaled = scaler.transform(X_test)
+
+        model = get_model(model_name)
+        model.fit(X_train_scaled, y_train)
+        preds = model.predict(X_test_scaled)
+
+        fold_daily = pd.DataFrame({"pred": preds, "actual": y_test}, index=test_df.index)
+        daily_frames.append(fold_daily)
+
+        trade_dates = test_df.index[::REBALANCE_STEP]
+        trade_frames.append(fold_daily.loc[trade_dates])
+
+        fold_results.append(FoldResult(test_year=test_year, n_train=len(train_df), n_test=len(test_df)))
+
+    if not daily_frames:
+        raise ValueError(
+            "No walk-forward folds produced results -- feature matrix likely "
+            "doesn't span enough history for the configured FIRST_TEST_YEAR."
+        )
+
+    oos_daily = pd.concat(daily_frames).sort_index()
+    oos_trade = pd.concat(trade_frames).sort_index()
+    return oos_daily, oos_trade, fold_results
+
+
+def build_positions(preds: pd.Series) -> pd.Series:
+    """Convert predicted returns into {-1, 0, +1} positions via an adaptive threshold.
+
+    threshold[t] = THRESHOLD_VOL_MULTIPLIER * rolling_std(preds, window)[t]
+
+    The rolling std is computed causally (a trailing, non-centered pandas
+    rolling window), so the threshold at trade date ``t`` only uses
+    predictions already made at or before ``t`` -- consistent with the
+    project's no-lookahead requirement. Using a fraction of the model's own
+    recent prediction dispersion (rather than a fixed cutoff like "trade if
+    |pred| > 0.5%") makes the conviction bar self-calibrating: a model that
+    outputs very small or very large predictions still trades at a sensible
+    frequency instead of always/never crossing a fixed threshold.
+    """
+    rolling_std = preds.rolling(THRESHOLD_ROLLING_WINDOW, min_periods=THRESHOLD_MIN_PERIODS).std()
+    threshold = THRESHOLD_VOL_MULTIPLIER * rolling_std
+
+    positions = pd.Series(0, index=preds.index, dtype=int)
+    positions[preds > threshold] = 1
+    positions[preds < -threshold] = -1
+    # Rows without enough history to compute a threshold yet (NaN) stay flat.
+    positions[threshold.isna()] = 0
+    return positions
+
+
+def compute_strategy_returns(oos_trade: pd.DataFrame) -> pd.DataFrame:
+    """Turn (prediction, realized-return) pairs into a costed strategy P&L series.
+
+    Each row is one non-overlapping ``FORWARD_HORIZON``-day holding period.
+    Gross return = position * realized forward return. Net return subtracts
+    a transaction cost proportional to the magnitude of the position change
+    from the prior period (e.g. flat->long costs 1 unit of turnover, long->
+    short costs 2 units, since that's economically two legs).
+    """
+    positions = build_positions(oos_trade["pred"])
+    prev_positions = positions.shift(1).fillna(0)
+    turnover = (positions - prev_positions).abs()
+
+    gross_return = positions * oos_trade["actual"]
+    cost = turnover * TRANSACTION_COST
+    net_return = gross_return - cost
+
+    return pd.DataFrame(
+        {
+            "pred": oos_trade["pred"],
+            "actual": oos_trade["actual"],
+            "position": positions,
+            "turnover": turnover,
+            "gross_return": gross_return,
+            "cost": cost,
+            "net_return": net_return,
+        },
+        index=oos_trade.index,
+    )
+
+
+def run_backtest_all_models(
+    feature_matrix: pd.DataFrame, feature_cols: List[str], model_names: List[str]
+) -> Dict[str, dict]:
+    """Run walk-forward validation + strategy backtest for every model.
+
+    Returns a dict keyed by model name, each containing the raw OOS
+    prediction frames plus the costed strategy returns frame.
+    """
+    results = {}
+    for model_name in model_names:
+        print(f"[backtest] Running walk-forward validation for '{model_name}'...")
+        oos_daily, oos_trade, fold_results = run_walk_forward(feature_matrix, feature_cols, model_name)
+        strategy = compute_strategy_returns(oos_trade)
+        for fr in fold_results:
+            print(f"[backtest]   {model_name} | fold {fr.test_year}: "
+                  f"train={fr.n_train} rows, test={fr.n_test} rows")
+        results[model_name] = {
+            "oos_daily": oos_daily,
+            "oos_trade": oos_trade,
+            "strategy": strategy,
+            "fold_results": fold_results,
+        }
+    return results

--- a/crude-ml-prediction/src/data_loader.py
+++ b/crude-ml-prediction/src/data_loader.py
@@ -1,0 +1,207 @@
+"""Data acquisition layer.
+
+Downloads daily prices for WTI crude and a small set of macro / cross-asset
+series that are commonly cited as short-horizon drivers of crude oil
+returns, then aligns them onto a single trading calendar. Prices are cached
+to disk so that repeated runs of the pipeline do not re-hit yfinance.
+
+An optional EIA (U.S. Energy Information Administration) module can pull
+weekly commercial crude inventory levels -- the single most closely watched
+fundamental data release for WTI -- but only if an ``EIA_API_KEY``
+environment variable is present. The base pipeline must run with zero API
+keys, so this module fails soft (prints a message and returns ``None``)
+when the key is absent or the request fails.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import requests
+import yfinance as yf
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Ticker -> human readable column name. CL=F (WTI) is the prediction target;
+# the rest are candidate macro/fundamental drivers used in features.py.
+TICKERS: dict[str, str] = {
+    "CL=F": "WTI",
+    "BZ=F": "BRENT",
+    "RB=F": "RBOB",
+    "DX-Y.NYB": "DXY",
+    "^TNX": "UST10Y",
+    "XLE": "XLE",
+    "^VIX": "VIX",
+}
+
+START_DATE = "2010-01-01"
+FFILL_LIMIT_DAYS = 3  # bridge short holiday/holiday-mismatch gaps only, never a real data outage
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+PRICES_CACHE_PATH = DATA_DIR / "prices.parquet"
+
+# EIA v2 API: "Weekly U.S. Ending Stocks of Crude Oil Excluding SPR" (thousand barrels).
+# https://www.eia.gov/opendata/browser/petroleum/stoc/wstk
+EIA_SERIES_ID = "WCESTUS1"
+EIA_BASE_URL = "https://api.eia.gov/v2/petroleum/stoc/wstk/data/"
+EIA_TRAILING_WEEKS = 4  # window for the "surprise vs. recent trend" baseline
+
+
+class DataDownloadError(RuntimeError):
+    """Raised when a required price series cannot be downloaded from yfinance."""
+
+
+def _download_single_series(ticker: str, start: str, end: Optional[str]) -> pd.Series:
+    """Download one ticker's daily Close series from yfinance.
+
+    Downloading tickers one at a time (rather than a single multi-ticker
+    call) keeps the yfinance response shape simple and lets us raise a
+    precise error naming the ticker that failed, instead of a generic
+    failure for the whole batch.
+    """
+    try:
+        raw = yf.download(
+            ticker, start=start, end=end, progress=False, auto_adjust=False
+        )
+    except Exception as exc:  # network errors, rate limiting, etc.
+        raise DataDownloadError(
+            f"yfinance download failed for '{ticker}': {exc}"
+        ) from exc
+
+    if raw is None or raw.empty or "Close" not in raw:
+        raise DataDownloadError(
+            f"yfinance returned no data for '{ticker}'. The ticker may be "
+            "delisted/renamed or Yahoo Finance may be temporarily unavailable."
+        )
+
+    close = raw["Close"]
+    if isinstance(close, pd.DataFrame):  # defensive: some yfinance versions nest columns
+        close = close.iloc[:, 0]
+    return close.rename(ticker)
+
+
+def download_prices(
+    start: str = START_DATE,
+    end: Optional[str] = None,
+    force_refresh: bool = False,
+) -> pd.DataFrame:
+    """Download and align daily Close prices for all tickers in ``TICKERS``.
+
+    Returns a DataFrame indexed by trading date with one column per series
+    (human-readable names, e.g. "WTI", "BRENT", ...). Missing values from
+    minor exchange-calendar mismatches are forward-filled for at most
+    ``FFILL_LIMIT_DAYS`` days; any longer gap is left as NaN and the row is
+    dropped, since silently carrying a stale price further would corrupt
+    downstream return calculations.
+
+    Results are cached to ``data/prices.parquet``; pass ``force_refresh=True``
+    to bypass the cache and re-download.
+    """
+    if PRICES_CACHE_PATH.exists() and not force_refresh:
+        cached = pd.read_parquet(PRICES_CACHE_PATH)
+        print(f"[data_loader] Loaded cached prices from {PRICES_CACHE_PATH} "
+              f"({cached.index.min().date()} to {cached.index.max().date()}, {len(cached)} rows).")
+        return cached
+
+    print(f"[data_loader] Downloading {len(TICKERS)} series from yfinance "
+          f"({start} to {end or 'present'})...")
+    series_list = []
+    for ticker, name in TICKERS.items():
+        s = _download_single_series(ticker, start, end)
+        s.name = name
+        series_list.append(s)
+        print(f"[data_loader]   {name} ({ticker}): {len(s)} rows")
+
+    prices = pd.concat(series_list, axis=1).sort_index()
+    prices = prices.ffill(limit=FFILL_LIMIT_DAYS)
+    n_before = len(prices)
+    prices = prices.dropna()
+    n_after = len(prices)
+    if n_after < n_before:
+        print(f"[data_loader] Dropped {n_before - n_after} rows with unresolvable gaps "
+              f"(> {FFILL_LIMIT_DAYS} consecutive missing days).")
+
+    if prices.empty:
+        raise DataDownloadError(
+            "Aligned price panel is empty after cleaning -- check ticker availability."
+        )
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    prices.to_parquet(PRICES_CACHE_PATH)
+    print(f"[data_loader] Cached {len(prices)} rows to {PRICES_CACHE_PATH}.")
+    return prices
+
+
+def fetch_eia_inventories(start: str = START_DATE, end: Optional[str] = None) -> Optional[pd.Series]:
+    """Fetch weekly U.S. commercial crude inventory levels from the EIA v2 API.
+
+    Inventory draws/builds relative to expectations are a primary short-term
+    driver of WTI price action, but the EIA API requires a free API key.
+    To keep the base project key-free, this function is purely additive: it
+    returns ``None`` (and prints an explanatory message) whenever
+    ``EIA_API_KEY`` is not set or the request fails for any reason, and the
+    rest of the pipeline treats that as "no inventory feature available".
+    """
+    api_key = os.environ.get("EIA_API_KEY")
+    if not api_key:
+        print("[data_loader] EIA_API_KEY not set -- skipping optional inventory module "
+              "(this is expected for the base project; results are unaffected).")
+        return None
+
+    params = {
+        "api_key": api_key,
+        "frequency": "weekly",
+        "data[0]": "value",
+        "facets[series][]": EIA_SERIES_ID,
+        "start": start,
+        "sort[0][column]": "period",
+        "sort[0][direction]": "asc",
+        "length": 5000,
+    }
+    if end:
+        params["end"] = end
+
+    try:
+        resp = requests.get(EIA_BASE_URL, params=params, timeout=30)
+        resp.raise_for_status()
+        payload = resp.json()
+        records = payload["response"]["data"]
+        if not records:
+            raise ValueError("EIA API returned zero records")
+        df = pd.DataFrame(records)
+        df["period"] = pd.to_datetime(df["period"])
+        series = df.set_index("period")["value"].astype(float).sort_index()
+        series.name = "eia_crude_stocks"
+        print(f"[data_loader] Fetched {len(series)} weekly EIA inventory observations.")
+        return series
+    except Exception as exc:
+        print(f"[data_loader] EIA fetch failed ({exc}); continuing without inventory feature.")
+        return None
+
+
+def build_inventory_surprise_daily(
+    weekly_stocks: pd.Series, trading_days_index: pd.DatetimeIndex
+) -> pd.Series:
+    """Convert weekly EIA inventory levels into a daily "inventory surprise" feature.
+
+    Surprise is defined as this week's stock change minus the trailing
+    ``EIA_TRAILING_WEEKS``-week average change -- i.e. how unusual the
+    latest build/draw was relative to the recent trend, which is closer to
+    what actually moves markets than the raw level. The weekly value is
+    forward-filled onto the daily trading calendar because the market only
+    learns the new number once per week (each Wednesday release) and prices
+    the same figure in on every subsequent trading day until the next
+    release -- forward-fill (not interpolation) is what keeps this
+    lookahead-safe.
+    """
+    weekly_change = weekly_stocks.diff()
+    trailing_avg_change = weekly_change.rolling(EIA_TRAILING_WEEKS).mean()
+    surprise = weekly_change - trailing_avg_change
+    daily = surprise.reindex(trading_days_index, method="ffill")
+    daily.name = "inventory_surprise"
+    return daily

--- a/crude-ml-prediction/src/evaluate.py
+++ b/crude-ml-prediction/src/evaluate.py
@@ -1,0 +1,412 @@
+"""Performance evaluation, charting, and reporting.
+
+Computes trading-strategy performance metrics (Sharpe, drawdown, hit rate,
+annualized return/vol) both gross and net of transaction costs, benchmarks
+the strategy against a buy-and-hold WTI position, and renders three charts
+plus a machine-readable metrics file:
+
+* ``results/equity_curve.png``       -- strategy vs. buy-and-hold equity curves
+* ``results/feature_importance.png`` -- XGBoost gain importance + Lasso coefficients
+* ``results/pred_scatter.png``       -- predicted vs. realized returns, IC annotated
+* ``results/metrics.json``           -- every number below, machine-readable
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+from src.features import FORWARD_HORIZON, TARGET_COL
+from src.models import get_model
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TRADING_DAYS_PER_YEAR = 252
+PERIODS_PER_YEAR = TRADING_DAYS_PER_YEAR / FORWARD_HORIZON  # ~50.4 non-overlapping 5d holds/year
+
+HIGH_SHARPE_WARNING_THRESHOLD = 2.5  # flag for a lookahead-bias hunt, not a celebration
+
+RESULTS_DIR = Path(__file__).resolve().parent.parent / "results"
+
+# --- Chart palette (validated categorical palette; see dataviz skill) -----
+COLOR_SURFACE = "#fcfcfb"
+COLOR_GRID = "#e1e0d9"
+COLOR_AXIS = "#c3c2b7"
+COLOR_TEXT_PRIMARY = "#0b0b0b"
+COLOR_TEXT_SECONDARY = "#52514e"
+COLOR_TEXT_MUTED = "#898781"
+
+MODEL_COLORS: Dict[str, str] = {
+    "baseline": "#898781",  # muted grey -- "predict nothing" null reference
+    "ridge": "#2a78d6",     # categorical slot 1 (blue)
+    "lasso": "#1baf7a",     # categorical slot 2 (aqua)
+    "xgboost": "#008300",   # categorical slot 4 (green) -- slot 3 (yellow) skipped for contrast
+}
+BENCHMARK_COLOR = "#0b0b0b"  # primary ink -- "the market", the ultimate comparison
+
+
+# ---------------------------------------------------------------------------
+# Core metric functions
+# ---------------------------------------------------------------------------
+
+def annualized_sharpe(returns: pd.Series, periods_per_year: float) -> float:
+    """Mean/std of periodic returns, annualized by sqrt(periods_per_year)."""
+    if returns.empty or returns.std(ddof=1) == 0:
+        return 0.0
+    return float(returns.mean() / returns.std(ddof=1) * np.sqrt(periods_per_year))
+
+
+def max_drawdown(equity: pd.Series) -> float:
+    """Largest peak-to-trough decline of an equity curve, as a negative fraction."""
+    if equity.empty:
+        return 0.0
+    running_max = equity.cummax()
+    drawdown = equity / running_max - 1.0
+    return float(drawdown.min())
+
+
+def hit_rate(strategy_df: pd.DataFrame) -> float:
+    """Fraction of actual trades (nonzero position) with a positive net return."""
+    traded = strategy_df[strategy_df["position"] != 0]
+    if traded.empty:
+        return float("nan")
+    return float((traded["net_return"] > 0).mean())
+
+
+def annualized_return_periodic(returns: pd.Series, periods_per_year: float) -> float:
+    """Geometric annualized return from a series of periodic (non-overlapping) returns."""
+    n = len(returns)
+    if n == 0:
+        return 0.0
+    equity_final = float((1.0 + returns).prod())
+    years = n / periods_per_year
+    if years <= 0 or equity_final <= 0:
+        return float("nan")
+    return equity_final ** (1.0 / years) - 1.0
+
+
+def annualized_vol_periodic(returns: pd.Series, periods_per_year: float) -> float:
+    if returns.empty:
+        return 0.0
+    return float(returns.std(ddof=1) * np.sqrt(periods_per_year))
+
+
+def compute_strategy_metrics(strategy_df: pd.DataFrame) -> Dict[str, float]:
+    """Full metric set for a costed strategy return series, gross and net."""
+    gross_equity = (1.0 + strategy_df["gross_return"]).cumprod()
+    net_equity = (1.0 + strategy_df["net_return"]).cumprod()
+
+    n_trades = int((strategy_df["position"] != 0).sum())
+    return {
+        "n_periods": int(len(strategy_df)),
+        "n_trades": n_trades,
+        "hit_rate": hit_rate(strategy_df),
+        "sharpe_gross": annualized_sharpe(strategy_df["gross_return"], PERIODS_PER_YEAR),
+        "sharpe_net": annualized_sharpe(strategy_df["net_return"], PERIODS_PER_YEAR),
+        "annualized_return_gross": annualized_return_periodic(strategy_df["gross_return"], PERIODS_PER_YEAR),
+        "annualized_return_net": annualized_return_periodic(strategy_df["net_return"], PERIODS_PER_YEAR),
+        "annualized_vol_gross": annualized_vol_periodic(strategy_df["gross_return"], PERIODS_PER_YEAR),
+        "annualized_vol_net": annualized_vol_periodic(strategy_df["net_return"], PERIODS_PER_YEAR),
+        "max_drawdown_gross": max_drawdown(gross_equity),
+        "max_drawdown_net": max_drawdown(net_equity),
+        "total_transaction_cost": float(strategy_df["cost"].sum()),
+    }
+
+
+def buy_and_hold_benchmark(prices: pd.DataFrame, start: pd.Timestamp, end: pd.Timestamp) -> Dict[str, object]:
+    """Buy-and-hold WTI benchmark over the same out-of-sample window as the strategy."""
+    wti = prices.loc[(prices.index >= start) & (prices.index <= end), "WTI"]
+    daily_log_return = np.log(wti).diff().dropna()
+    equity = np.exp(daily_log_return.cumsum())
+
+    n = len(daily_log_return)
+    years = n / TRADING_DAYS_PER_YEAR
+    ann_return = float(equity.iloc[-1] ** (1.0 / years) - 1.0) if years > 0 else float("nan")
+
+    metrics = {
+        "sharpe": annualized_sharpe(daily_log_return, TRADING_DAYS_PER_YEAR),
+        "annualized_return": ann_return,
+        "annualized_vol": annualized_vol_periodic(daily_log_return, TRADING_DAYS_PER_YEAR),
+        "max_drawdown": max_drawdown(equity),
+    }
+    return {"daily_log_return": daily_log_return, "equity": equity, "metrics": metrics}
+
+
+def per_year_table(strategy_df: pd.DataFrame) -> pd.DataFrame:
+    """Per-calendar-year performance breakdown for the trading strategy."""
+    rows = []
+    for year, group in strategy_df.groupby(strategy_df.index.year):
+        rows.append(
+            {
+                "year": int(year),
+                "n_trades": int((group["position"] != 0).sum()),
+                "hit_rate": hit_rate(group),
+                "gross_return": float((1.0 + group["gross_return"]).prod() - 1.0),
+                "net_return": float((1.0 + group["net_return"]).prod() - 1.0),
+                "sharpe_net": annualized_sharpe(group["net_return"], PERIODS_PER_YEAR),
+            }
+        )
+    return pd.DataFrame(rows).set_index("year")
+
+
+def information_coefficient(oos_daily: pd.DataFrame) -> float:
+    """Spearman rank correlation between predicted and realized forward returns.
+
+    Undefined (NaN) when predictions are constant -- e.g. the always-zero
+    baseline -- since rank correlation requires variation in both inputs.
+    """
+    if len(oos_daily) < 2 or oos_daily["pred"].nunique() < 2:
+        return float("nan")
+    return float(oos_daily["pred"].corr(oos_daily["actual"], method="spearman"))
+
+
+# ---------------------------------------------------------------------------
+# Charts
+# ---------------------------------------------------------------------------
+
+def _style_axes(ax: plt.Axes) -> None:
+    ax.set_facecolor(COLOR_SURFACE)
+    ax.grid(True, color=COLOR_GRID, linewidth=0.8, zorder=0)
+    ax.set_axisbelow(True)
+    for spine in ("top", "right"):
+        ax.spines[spine].set_visible(False)
+    for spine in ("left", "bottom"):
+        ax.spines[spine].set_color(COLOR_AXIS)
+    ax.tick_params(colors=COLOR_TEXT_MUTED, labelsize=9)
+    ax.xaxis.label.set_color(COLOR_TEXT_SECONDARY)
+    ax.yaxis.label.set_color(COLOR_TEXT_SECONDARY)
+
+
+def plot_equity_curve(
+    backtest_results: Dict[str, dict], benchmark: Dict[str, object], out_path: Path = RESULTS_DIR / "equity_curve.png"
+) -> None:
+    """Strategy (net of costs) equity curves for every model vs. buy-and-hold WTI."""
+    fig, ax = plt.subplots(figsize=(10, 6), facecolor=COLOR_SURFACE)
+    _style_axes(ax)
+
+    bh_equity = benchmark["equity"]
+    ax.plot(bh_equity.index, bh_equity.values, color=BENCHMARK_COLOR, linewidth=2,
+            linestyle="--", label="Buy & Hold WTI", zorder=3)
+
+    for model_name, res in backtest_results.items():
+        equity = (1.0 + res["strategy"]["net_return"]).cumprod()
+        ax.plot(equity.index, equity.values, color=MODEL_COLORS.get(model_name, COLOR_TEXT_MUTED),
+                 linewidth=2, label=f"{model_name} (net)", zorder=4)
+
+    ax.axhline(1.0, color=COLOR_AXIS, linewidth=1, zorder=1)
+    ax.set_title("Strategy Equity Curves vs. Buy & Hold WTI", color=COLOR_TEXT_PRIMARY,
+                 fontsize=13, fontweight="bold", loc="left", pad=12)
+    ax.set_ylabel("Growth of $1")
+    ax.set_xlabel("Date")
+    ax.legend(loc="upper left", frameon=False, fontsize=9, labelcolor=COLOR_TEXT_SECONDARY)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150, facecolor=COLOR_SURFACE)
+    plt.close(fig)
+    print(f"[evaluate] Saved {out_path}")
+
+
+def _fit_full_sample_for_interpretability(feature_matrix: pd.DataFrame, feature_cols: List[str]):
+    """Refit XGBoost and Lasso on the ENTIRE dataset, for interpretability charts only.
+
+    This is intentionally separate from the walk-forward backtest: fitting on
+    all available data (rather than a single training fold) gives the most
+    stable, least noisy picture of which features a model leans on overall.
+    It is never used to generate a prediction or a P&L number, so it carries
+    no lookahead risk for anything performance-related -- it only answers
+    "what did the model learn," not "how would it have traded."
+    """
+    X = feature_matrix[feature_cols].values
+    y = feature_matrix[TARGET_COL].values
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+
+    xgb_model = get_model("xgboost")
+    xgb_model.fit(X_scaled, y)
+
+    lasso_model = get_model("lasso")
+    lasso_model.fit(X_scaled, y)
+
+    return xgb_model, lasso_model
+
+
+def plot_feature_importance(
+    feature_matrix: pd.DataFrame, feature_cols: List[str], out_path: Path = RESULTS_DIR / "feature_importance.png"
+) -> None:
+    """XGBoost gain-based importance and Lasso nonzero coefficients, side by side."""
+    xgb_model, lasso_model = _fit_full_sample_for_interpretability(feature_matrix, feature_cols)
+
+    xgb_importance = pd.Series(xgb_model.feature_importances_, index=feature_cols).sort_values()
+    lasso_coef = pd.Series(lasso_model.coef_, index=feature_cols)
+    lasso_coef = lasso_coef[lasso_coef != 0].sort_values()
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 6), facecolor=COLOR_SURFACE)
+
+    ax = axes[0]
+    _style_axes(ax)
+    ax.barh(xgb_importance.index, xgb_importance.values, color=MODEL_COLORS["xgboost"], zorder=3)
+    ax.set_title("XGBoost Feature Importance (gain)", color=COLOR_TEXT_PRIMARY, fontsize=12,
+                 fontweight="bold", loc="left")
+    ax.set_xlabel("Gain")
+
+    ax = axes[1]
+    _style_axes(ax)
+    if lasso_coef.empty:
+        ax.text(0.5, 0.5, "Lasso selected zero features\n(all coefficients shrunk to 0)",
+                ha="center", va="center", color=COLOR_TEXT_MUTED, fontsize=10, transform=ax.transAxes)
+    else:
+        bar_colors = [MODEL_COLORS["lasso"] if v > 0 else "#e34948" for v in lasso_coef.values]
+        ax.barh(lasso_coef.index, lasso_coef.values, color=bar_colors, zorder=3)
+        ax.axvline(0, color=COLOR_AXIS, linewidth=1)
+    ax.set_title("Lasso Nonzero Coefficients", color=COLOR_TEXT_PRIMARY, fontsize=12,
+                 fontweight="bold", loc="left")
+    ax.set_xlabel("Standardized coefficient")
+
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150, facecolor=COLOR_SURFACE)
+    plt.close(fig)
+    print(f"[evaluate] Saved {out_path}")
+
+
+def plot_pred_scatter(
+    backtest_results: Dict[str, dict], out_path: Path = RESULTS_DIR / "pred_scatter.png"
+) -> None:
+    """Predicted vs. realized forward 5d returns for each model, IC annotated.
+
+    Uses the full daily out-of-sample prediction set (not the 5-day-spaced
+    trading subset) since this chart measures raw forecast skill, not
+    trading P&L -- see backtest.py module docstring for why the two
+    prediction sets are kept separate.
+    """
+    model_names = list(backtest_results.keys())
+    fig, axes = plt.subplots(2, 2, figsize=(11, 10), facecolor=COLOR_SURFACE)
+    axes = axes.flatten()
+
+    for ax, model_name in zip(axes, model_names):
+        _style_axes(ax)
+        oos_daily = backtest_results[model_name]["oos_daily"]
+        ic = information_coefficient(oos_daily)
+        color = MODEL_COLORS.get(model_name, COLOR_TEXT_MUTED)
+
+        ax.scatter(oos_daily["pred"], oos_daily["actual"], s=10, alpha=0.35,
+                   color=color, edgecolors="none", zorder=3)
+        ax.axhline(0, color=COLOR_AXIS, linewidth=1, zorder=2)
+        ax.axvline(0, color=COLOR_AXIS, linewidth=1, zorder=2)
+        ax.set_title(f"{model_name}  (IC = {ic:.3f})", color=COLOR_TEXT_PRIMARY,
+                     fontsize=11, fontweight="bold", loc="left")
+        ax.set_xlabel("Predicted 5d log return")
+        ax.set_ylabel("Realized 5d log return")
+
+    for ax in axes[len(model_names):]:
+        ax.axis("off")
+
+    fig.suptitle("Predicted vs. Realized Returns (out-of-sample)", color=COLOR_TEXT_PRIMARY,
+                 fontsize=13, fontweight="bold", x=0.02, ha="left")
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    fig.savefig(out_path, dpi=150, facecolor=COLOR_SURFACE)
+    plt.close(fig)
+    print(f"[evaluate] Saved {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def build_full_report(
+    backtest_results: Dict[str, dict], prices: pd.DataFrame
+) -> Dict[str, object]:
+    """Assemble the complete metrics dict (per model + benchmark) for saving/printing."""
+    all_dates = pd.concat([r["oos_trade"] for r in backtest_results.values()]).index
+    oos_start, oos_end = all_dates.min(), all_dates.max()
+    benchmark = buy_and_hold_benchmark(prices, oos_start, oos_end)
+
+    report: Dict[str, object] = {
+        "oos_period": {"start": str(oos_start.date()), "end": str(oos_end.date())},
+        "benchmark_buy_and_hold_wti": benchmark["metrics"],
+        "models": {},
+    }
+    for model_name, res in backtest_results.items():
+        strategy_metrics = compute_strategy_metrics(res["strategy"])
+        report["models"][model_name] = {
+            **strategy_metrics,
+            "information_coefficient": information_coefficient(res["oos_daily"]),
+            "per_year": per_year_table(res["strategy"]).reset_index().to_dict(orient="records"),
+        }
+    return report, benchmark
+
+
+def _sanitize_for_json(obj: object) -> object:
+    """Recursively replace NaN/inf floats with None so the output is standard JSON."""
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_json(v) for v in obj]
+    if isinstance(obj, float) and not np.isfinite(obj):
+        return None
+    return obj
+
+
+def save_metrics_json(report: Dict[str, object], out_path: Path = RESULTS_DIR / "metrics.json") -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(_sanitize_for_json(report), f, indent=2, default=str)
+    print(f"[evaluate] Saved {out_path}")
+
+
+def print_summary_table(report: Dict[str, object]) -> None:
+    """Console summary: one row per model, net Sharpe vs. buy-and-hold benchmark."""
+    bh = report["benchmark_buy_and_hold_wti"]
+    print("\n" + "=" * 78)
+    print(f"OUT-OF-SAMPLE PERIOD: {report['oos_period']['start']} to {report['oos_period']['end']}")
+    print("=" * 78)
+    print(f"{'Model':<10} {'Sharpe(net)':>12} {'Sharpe(gross)':>14} {'AnnRet(net)':>12} "
+          f"{'MaxDD(net)':>11} {'HitRate':>9} {'Trades':>7} {'IC':>7}")
+    print("-" * 78)
+    for model_name, m in report["models"].items():
+        print(f"{model_name:<10} {m['sharpe_net']:>12.2f} {m['sharpe_gross']:>14.2f} "
+              f"{m['annualized_return_net']:>12.2%} {m['max_drawdown_net']:>11.2%} "
+              f"{m['hit_rate']:>9.2%} {m['n_trades']:>7d} {m['information_coefficient']:>7.3f}")
+    print("-" * 78)
+    print(f"{'Buy&Hold':<10} {bh['sharpe']:>12.2f} {'--':>14} {bh['annualized_return']:>12.2%} "
+          f"{bh['max_drawdown']:>11.2%} {'--':>9} {'--':>7} {'--':>7}")
+    print("=" * 78)
+
+    high_sharpe_models = [
+        name for name, m in report["models"].items()
+        if name != "baseline" and m["sharpe_net"] > HIGH_SHARPE_WARNING_THRESHOLD
+    ]
+    if high_sharpe_models:
+        print(f"\n[WARNING] Net Sharpe > {HIGH_SHARPE_WARNING_THRESHOLD} for: {', '.join(high_sharpe_models)}.")
+        print("  A Sharpe this high on daily/weekly macro features is very unusual --")
+        print("  treat this as a signal to re-run verify_no_lookahead() and audit the")
+        print("  feature/scaler/fold boundaries for leakage before trusting the result.")
+    print()
+
+
+def evaluate(
+    backtest_results: Dict[str, dict],
+    feature_matrix: pd.DataFrame,
+    feature_cols: List[str],
+    prices: pd.DataFrame,
+) -> Dict[str, object]:
+    """Run the full evaluation stage: metrics, charts, JSON, console summary."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    report, benchmark = build_full_report(backtest_results, prices)
+
+    plot_equity_curve(backtest_results, benchmark)
+    plot_feature_importance(feature_matrix, feature_cols)
+    plot_pred_scatter(backtest_results)
+    save_metrics_json(report)
+    print_summary_table(report)
+
+    return report

--- a/crude-ml-prediction/src/features.py
+++ b/crude-ml-prediction/src/features.py
@@ -1,0 +1,249 @@
+"""Feature engineering for the WTI 5-day-forward return prediction task.
+
+Every feature is constructed so that its value at time ``t`` uses only
+information available up to and including ``t`` (prices realized at the
+close of day ``t``). Only the TARGET column deliberately looks forward --
+that is what a supervised model needs to learn to predict, and its
+alignment is exercised by :func:`verify_no_lookahead` below.
+
+Feature construction is deliberately split into two stages:
+
+* :func:`compute_price_features` builds every feature from a price panel
+  alone. It is a pure function of its input, which means it can be re-run
+  on a *truncated* price history to prove that features computed "as of"
+  some historical date do not change when future rows are added -- this is
+  exactly what :func:`verify_no_lookahead` does.
+* :func:`add_target` appends the (forward-looking) label.
+
+Standardization is intentionally NOT done here. Fitting a scaler on the
+full dataset before splitting into train/test would leak the test period's
+mean/variance into the training process, so scaling happens per walk-forward
+fold, on training data only, inside ``backtest.py``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Constants (feature windows, all in trading days unless noted)
+# ---------------------------------------------------------------------------
+
+MOMENTUM_WINDOWS: List[int] = [5, 21, 63]  # ~1 week, ~1 month, ~1 quarter
+REALIZED_VOL_WINDOW = 21
+TRADING_DAYS_PER_YEAR = 252
+SPREAD_CHANGE_WINDOW = 5
+CRACK_SPREAD_WINDOW = 5
+DXY_CHANGE_WINDOWS: List[int] = [5, 21]
+YIELD_CHANGE_WINDOW = 5
+VIX_CHANGE_WINDOW = 5
+XLE_RELATIVE_WINDOW = 21
+FORWARD_HORIZON = 5  # prediction target horizon, in trading days
+
+TARGET_COL = "target_fwd_5d_logret"
+
+RANDOM_SEED = 42
+
+
+def _log(series: pd.Series) -> pd.Series:
+    return np.log(series)
+
+
+def compute_price_features(prices: pd.DataFrame, eia_daily: Optional[pd.Series] = None) -> pd.DataFrame:
+    """Build the feature matrix from a price panel (no target column).
+
+    Parameters
+    ----------
+    prices:
+        DataFrame with columns WTI, BRENT, RBOB, DXY, UST10Y, XLE, VIX,
+        indexed by trading date (as produced by ``data_loader.download_prices``).
+    eia_daily:
+        Optional daily-aligned inventory-surprise series from
+        ``data_loader.build_inventory_surprise_daily``. Omitted entirely
+        (not just NaN-filled) when the EIA module is inactive, so the
+        feature set silently shrinks by one column rather than injecting a
+        constant/NaN feature.
+
+    Every feature below is purely a function of ``prices.loc[:t]`` -- pandas
+    ``.diff()`` / ``.rolling()`` only look backward from each row, so no
+    step here can leak future information. See module docstring.
+    """
+    wti_log = _log(prices["WTI"])
+    wti_daily_logret = wti_log.diff()
+
+    feats = pd.DataFrame(index=prices.index)
+
+    # --- Momentum: persistence of recent trend. Crude exhibits short-run
+    # trend-following behavior driven by CTA/systematic flow, so recent
+    # cumulative returns at multiple horizons capture that momentum regime.
+    for window in MOMENTUM_WINDOWS:
+        feats[f"mom_{window}d"] = wti_log.diff(window)
+
+    # --- Realized volatility: regime indicator. High recent vol tends to
+    # cluster (GARCH effect) and correlates with wider risk premia / less
+    # reliable mean-reversion, which is useful context for a return model.
+    feats["realized_vol_21d"] = (
+        wti_daily_logret.rolling(REALIZED_VOL_WINDOW).std() * np.sqrt(TRADING_DAYS_PER_YEAR)
+    )
+
+    # --- Brent-WTI spread: proxy for regional supply/demand tightness and
+    # transport/export bottlenecks (e.g. Cushing storage, pipeline capacity).
+    # A widening spread historically signals WTI-specific weakness.
+    brent_wti_spread = prices["BRENT"] - prices["WTI"]
+    feats["brent_wti_spread"] = brent_wti_spread
+    feats["brent_wti_spread_chg_5d"] = brent_wti_spread.diff(SPREAD_CHANGE_WINDOW)
+
+    # --- Crack spread proxy: RBOB (gasoline) return minus WTI return, summed
+    # over a rolling window. Approximates refining margin momentum; refiners
+    # pulling more crude through the system (strong crack spread) signals
+    # downstream demand strength that leads crude prices.
+    rbob_daily_logret = _log(prices["RBOB"]).diff()
+    feats["crack_spread_proxy_5d"] = (rbob_daily_logret - wti_daily_logret).rolling(
+        CRACK_SPREAD_WINDOW
+    ).sum()
+
+    # --- Dollar index: crude is dollar-denominated globally, so a stronger
+    # dollar mechanically raises crude's cost to non-USD buyers -- a
+    # standard headwind for commodity prices.
+    dxy_log = _log(prices["DXY"])
+    for window in DXY_CHANGE_WINDOWS:
+        feats[f"dxy_chg_{window}d"] = dxy_log.diff(window)
+
+    # --- 10Y Treasury yield change: proxy for growth/inflation expectations
+    # and the discount rate applied to future energy demand.
+    feats["ust10y_chg_5d"] = prices["UST10Y"].diff(YIELD_CHANGE_WINDOW)
+
+    # --- VIX: broad risk-appetite regime. Elevated equity vol tends to
+    # coincide with de-risking across commodities regardless of crude-
+    # specific fundamentals.
+    feats["vix_level"] = prices["VIX"]
+    feats["vix_chg_5d"] = prices["VIX"].diff(VIX_CHANGE_WINDOW)
+
+    # --- XLE relative strength: energy-equity investors often re-price
+    # forward earnings expectations ahead of the spot commodity, so XLE
+    # outperformance/underperformance vs. WTI can lead the crude move.
+    xle_21d = _log(prices["XLE"]).diff(XLE_RELATIVE_WINDOW)
+    wti_21d = wti_log.diff(XLE_RELATIVE_WINDOW)
+    feats["xle_relative_strength_21d"] = xle_21d - wti_21d
+
+    # --- Optional EIA inventory surprise (see data_loader.build_inventory_surprise_daily).
+    if eia_daily is not None:
+        feats["inventory_surprise"] = eia_daily.reindex(feats.index)
+
+    return feats
+
+
+def add_target(feats: pd.DataFrame, prices: pd.DataFrame, horizon: int = FORWARD_HORIZON) -> pd.DataFrame:
+    """Append the forward ``horizon``-day WTI log return as the prediction target.
+
+    ``target[t] = log(P[t+horizon]) - log(P[t])``, implemented as
+    ``wti_log.shift(-horizon) - wti_log``. This is the ONLY place future
+    information enters the DataFrame, by design -- the label a supervised
+    model is trained to predict must be observed strictly after the
+    feature vector's timestamp ``t``. The last ``horizon`` rows will have
+    NaN targets (no future price yet exists) and are dropped downstream.
+    """
+    out = feats.copy()
+    wti_log = _log(prices["WTI"]).reindex(feats.index)
+    out[TARGET_COL] = wti_log.shift(-horizon) - wti_log
+    return out
+
+
+def build_feature_matrix(
+    prices: pd.DataFrame, eia_daily: Optional[pd.Series] = None
+) -> pd.DataFrame:
+    """Full pipeline: compute features, attach target, drop incomplete rows."""
+    feats = compute_price_features(prices, eia_daily)
+    full = add_target(feats, prices)
+    n_before = len(full)
+    full = full.dropna()
+    n_after = len(full)
+    print(f"[features] Built {full.shape[1] - 1} features on {n_after} rows "
+          f"(dropped {n_before - n_after} rows with warm-up/target NaNs).")
+    return full
+
+
+def get_feature_columns(feature_matrix: pd.DataFrame) -> List[str]:
+    """All columns except the target -- i.e. the model's input columns."""
+    return [c for c in feature_matrix.columns if c != TARGET_COL]
+
+
+def verify_no_lookahead(
+    prices: pd.DataFrame,
+    feature_matrix: pd.DataFrame,
+    eia_daily: Optional[pd.Series] = None,
+    n_checks: int = 25,
+    horizon: int = FORWARD_HORIZON,
+) -> bool:
+    """Unit-test-style check that no feature or target uses future data improperly.
+
+    Two independent checks:
+
+    1. **Feature causality**: for a random sample of dates ``t``, recompute
+       every feature using ONLY ``prices.loc[:t]`` (i.e. pretend the future
+       hasn't happened yet) and assert the result matches the value stored
+       in ``feature_matrix`` at ``t``. If any feature secretly depended on
+       rows after ``t`` (e.g. a centered rolling window, or an off-by-one
+       shift), truncating the input would change its value and this
+       assertion would fail.
+    2. **Target alignment**: for a random sample of dates ``t``, manually
+       recompute ``log(P[t+horizon]) - log(P[t])`` from the raw price panel
+       and assert it matches ``feature_matrix[TARGET_COL]`` at ``t`` --
+       catching off-by-one horizon bugs in :func:`add_target`.
+
+    Raises ``AssertionError`` on any mismatch. Returns ``True`` on success.
+    """
+    rng = np.random.default_rng(RANDOM_SEED)
+    feature_cols = get_feature_columns(feature_matrix)
+
+    # Only test dates with enough trailing history for the longest window
+    # (63d momentum) and enough remaining future rows for the target horizon.
+    max_lookback = max(MOMENTUM_WINDOWS)
+    eligible = feature_matrix.index[
+        (feature_matrix.index >= prices.index[max_lookback + 5])
+        & (feature_matrix.index <= prices.index[-(horizon + 1)])
+    ]
+    sample_size = min(n_checks, len(eligible))
+    if sample_size == 0:
+        raise AssertionError("No eligible dates to run lookahead checks on.")
+    check_dates = rng.choice(eligible, size=sample_size, replace=False)
+
+    for dt in check_dates:
+        truncated_prices = prices.loc[:dt]
+        truncated_feats = compute_price_features(truncated_prices, eia_daily)
+        for col in feature_cols:
+            if col not in truncated_feats.columns:
+                continue  # e.g. inventory_surprise absent from truncated EIA slice edge case
+            full_val = feature_matrix.loc[dt, col]
+            trunc_val = truncated_feats.loc[dt, col]
+            if pd.isna(full_val) and pd.isna(trunc_val):
+                continue
+            if not np.isclose(full_val, trunc_val, equal_nan=True, atol=1e-10):
+                raise AssertionError(
+                    f"Lookahead bias detected: feature '{col}' at {dt.date()} "
+                    f"changed from {trunc_val} to {full_val} when future rows were added."
+                )
+
+    # Target alignment check.
+    wti_log = _log(prices["WTI"])
+    target_check_dates = rng.choice(eligible, size=sample_size, replace=False)
+    for dt in target_check_dates:
+        loc = prices.index.get_loc(dt)
+        future_loc = loc + horizon
+        if future_loc >= len(prices.index):
+            continue
+        future_date = prices.index[future_loc]
+        expected = wti_log.loc[future_date] - wti_log.loc[dt]
+        actual = feature_matrix.loc[dt, TARGET_COL]
+        if not np.isclose(expected, actual, atol=1e-10):
+            raise AssertionError(
+                f"Target misalignment at {dt.date()}: expected fwd {horizon}d logret "
+                f"{expected:.6f} (using {future_date.date()}) but found {actual:.6f}."
+            )
+
+    print(f"[features] verify_no_lookahead passed: {sample_size} feature-causality checks "
+          f"and {sample_size} target-alignment checks, zero violations.")
+    return True

--- a/crude-ml-prediction/src/models.py
+++ b/crude-ml-prediction/src/models.py
@@ -1,0 +1,91 @@
+"""Model factory for the WTI return prediction task.
+
+Four models are compared, from simplest to most flexible:
+
+* ``baseline`` -- always predicts zero return. Since the target is
+  approximately mean-zero and near-random-walk, this is the correct null
+  hypothesis benchmark: any model that can't beat "predict nothing" has
+  learned nothing useful.
+* ``ridge`` / ``lasso`` -- linear models with L2/L1 regularization. Lasso's
+  sparsity is doubly useful here: it performs feature selection, and its
+  nonzero coefficients are directly interpretable as "which macro signal
+  the model actually uses" (see evaluate.py's feature importance chart).
+* ``xgboost`` -- gradient-boosted trees, deliberately kept SHALLOW
+  (``max_depth=3``) with a small number of weak estimators and row/column
+  subsampling. Daily financial return data has a very low signal-to-noise
+  ratio; a deep or high-capacity tree ensemble will happily memorize noise
+  in the training window and look great in-sample while adding nothing
+  (or actively hurting) out-of-sample. Shallow trees + subsampling here are
+  a deliberate regularization choice, not an oversight.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.linear_model import Lasso, Ridge
+from xgboost import XGBRegressor
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+RANDOM_SEED = 42
+
+RIDGE_ALPHA = 1.0
+
+LASSO_ALPHA = 0.001
+LASSO_MAX_ITER = 10_000
+
+XGB_N_ESTIMATORS = 100
+XGB_MAX_DEPTH = 3
+XGB_LEARNING_RATE = 0.05
+XGB_SUBSAMPLE = 0.8
+XGB_COLSAMPLE_BYTREE = 0.8
+
+MODEL_NAMES: List[str] = ["baseline", "ridge", "lasso", "xgboost"]
+
+
+class ZeroReturnBaseline(BaseEstimator, RegressorMixin):
+    """Always predicts a return of exactly zero.
+
+    This is the "do nothing / no edge" null model. Requiring every other
+    model to beat this baseline out-of-sample is a much higher bar than
+    beating an arbitrary constant, since near-zero is close to the true
+    unconditional mean of a short-horizon commodity return.
+    """
+
+    def fit(self, X: np.ndarray, y: np.ndarray | None = None) -> "ZeroReturnBaseline":
+        return self
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return np.zeros(len(X))
+
+
+def get_model(name: str) -> BaseEstimator:
+    """Return a freshly initialized, unfit model instance for ``name``.
+
+    A new instance is returned on every call (rather than a shared
+    singleton) so that each walk-forward fold trains a completely
+    independent model with no state carried over from a previous fold.
+    """
+    if name == "baseline":
+        return ZeroReturnBaseline()
+    if name == "ridge":
+        return Ridge(alpha=RIDGE_ALPHA)
+    if name == "lasso":
+        return Lasso(alpha=LASSO_ALPHA, max_iter=LASSO_MAX_ITER)
+    if name == "xgboost":
+        return XGBRegressor(
+            n_estimators=XGB_N_ESTIMATORS,
+            max_depth=XGB_MAX_DEPTH,
+            learning_rate=XGB_LEARNING_RATE,
+            subsample=XGB_SUBSAMPLE,
+            colsample_bytree=XGB_COLSAMPLE_BYTREE,
+            random_state=RANDOM_SEED,
+            n_jobs=-1,
+            importance_type="gain",
+        )
+    raise ValueError(f"Unknown model name '{name}'. Expected one of {MODEL_NAMES}.")


### PR DESCRIPTION
## Summary
- Adds `crude-ml-prediction/`, a self-contained project predicting 5-day-forward WTI crude oil returns from macro/fundamental features (momentum, realized vol, Brent-WTI spread, crack spread proxy, DXY, 10Y yield, VIX, XLE relative strength), with an optional EIA inventory-surprise feature gated behind `EIA_API_KEY`.
- Expanding-window walk-forward validation (retrained annually, `StandardScaler` fit per-fold on training data only) backs a long/short/flat trading strategy with an adaptive threshold and 3bps transaction costs, reported gross and net.
- `verify_no_lookahead()` proves feature causality and target alignment by recomputing features on truncated price history and asserting equality against the full feature matrix — this runs automatically before any backtesting in `main.py`.
- Four models compared via a factory (`baseline` / `ridge` / `lasso` / `xgboost`, the latter deliberately shallow) plus an evaluation stage producing an equity-curve chart, a feature-importance chart, a prediction-scatter chart with IC annotated, `metrics.json`, and a console summary.

## Known limitation
This sandbox's network egress policy blocks all outbound access to financial data providers (Yahoo Finance, Stooq, FRED, Nasdaq Data Link all return 403 from the proxy — this is a default-deny policy, not something specific to one provider), so I could not execute `main.py` against real data from this session. The pipeline was smoke-tested end-to-end against synthetic price data of the same schema (no crashes, valid charts/JSON, correct walk-forward fold behavior). The README's Key Results table is left as `X.XX` placeholders rather than fabricated numbers — real numbers need a run from an environment with internet access to a market data source.

## Test plan
- [x] `python -m py_compile` / `pyflakes` clean on all modules
- [x] End-to-end smoke test against synthetic price data: all 4 models train across 7 annual folds, charts render, `metrics.json` is valid JSON, runtime ~2s of compute
- [ ] Run against real WTI/Brent/RBOB/DXY/10Y/XLE/VIX data (blocked in this session — see above) and fill in README Key Results


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaiUht3gzombbBkw8c71wR)_